### PR TITLE
fix: update documentation links and repository URLs to use correct casing

### DIFF
--- a/docs/GETTING_STARTED.md
+++ b/docs/GETTING_STARTED.md
@@ -34,7 +34,7 @@ Before you begin, make sure you have:
 
 1. **Fork the Repository**
 
-   - Go to [RepoForge Repository](https://github.com/ryzncodes/repoforge)
+   - Go to [RepoForge Repository](https://github.com/ryzncodes/RepoForge)
    - Click the "Fork" button in the top right
    - Select your account as the destination
 
@@ -42,8 +42,8 @@ Before you begin, make sure you have:
 
    ```bash
    # Replace YOUR_USERNAME with your GitHub username
-   git clone https://github.com/YOUR_USERNAME/repoforge.git
-   cd repoforge
+   git clone https://github.com/YOUR_USERNAME/RepoForge.git
+   cd RepoForge
    ```
 
 3. **Install Dependencies**
@@ -56,7 +56,7 @@ Before you begin, make sure you have:
 
    ```bash
    # Add the original repository as a remote called "upstream"
-   git remote add upstream https://github.com/ryzncodes/repoforge.git
+   git remote add upstream https://github.com/ryzncodes/RepoForge.git
 
    # Create a new branch for your work
    git checkout -b my-first-task


### PR DESCRIPTION
## 📝 Description

This PR fixes case sensitivity issues in repository URLs and file paths to ensure all documentation links work correctly. GitHub URLs are case-sensitive, so this update ensures consistency across all references.

## 🔗 Related Issue(s)

Fixes broken documentation links that were returning 404 errors due to case sensitivity

## 🧪 Testing Done

- [x] Manual Testing Performed
  - Verified all repository URLs use correct casing (RepoForge)
  - Confirmed directory paths use correct case
  - Tested clone and upstream remote commands

## 📸 Screenshots

N/A - Documentation changes only

## ✅ Checklist

- [x] My code follows the project's style guidelines
- [x] I have updated the documentation accordingly
- [x] My changes generate no new warnings

## 📚 Additional Notes

Changes made:
- Updated repository URLs from `repoforge` to `RepoForge`
- Fixed clone URL casing in examples
- Updated directory path in clone instructions
- Fixed upstream remote URL casing

## 👥 Reviewer Focus

Please verify that:
- All repository URLs use correct casing (RepoForge)
- Clone and setup instructions work as written
- Directory paths are consistent

## 🔄 Type of Change

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [x] 📚 Documentation update